### PR TITLE
Add unit tests for static WH40K mission selection logic in mission_helper

### DIFF
--- a/CareBot/CareBot/import_armageddon_static_missions.py
+++ b/CareBot/CareBot/import_armageddon_static_missions.py
@@ -6,14 +6,18 @@ Usage:
 
 import asyncio
 import html
+import os
 import re
 from pathlib import Path
 from typing import Dict, List
 from urllib.parse import urljoin
 from urllib.request import urlopen, urlretrieve
 
-import sqllite_helper
+# Ensure a portable default DB path for local runs (can be overridden via DATABASE_PATH).
+DEFAULT_DB_PATH = Path(__file__).resolve().parent / "db" / "database.db"
+os.environ.setdefault("DATABASE_PATH", str(DEFAULT_DB_PATH))
 
+import sqllite_helper
 WAHAPEDIA_URL = "https://wahapedia.ru/wh40k10ed/the-rules/armageddon/#Mission-Map-Key"
 WAHAPEDIA_BASE_URL = "https://wahapedia.ru"
 SOURCE = "wahapedia_armageddon"

--- a/CareBot/CareBot/import_armageddon_static_missions.py
+++ b/CareBot/CareBot/import_armageddon_static_missions.py
@@ -1,0 +1,155 @@
+"""Import static Armageddon missions from Wahapedia into local database.
+
+Usage:
+    python CareBot/CareBot/import_armageddon_static_missions.py
+"""
+
+import asyncio
+import html
+import re
+from pathlib import Path
+from typing import Dict, List
+from urllib.parse import urljoin
+from urllib.request import urlopen, urlretrieve
+
+import sqllite_helper
+
+WAHAPEDIA_URL = "https://wahapedia.ru/wh40k10ed/the-rules/armageddon/#Mission-Map-Key"
+WAHAPEDIA_BASE_URL = "https://wahapedia.ru"
+SOURCE = "wahapedia_armageddon"
+RULES = "wh40k"
+
+ASSETS_DIR = Path(__file__).resolve().parent / "assets" / "deploys" / "armageddon"
+
+
+MISSION_BLOCK_RE = re.compile(
+    r'<a name="(?P<anchor>[^"]+)"></a>'
+    r'<div class="mission_header2">Armageddon Crusade Mission</div>'
+    r'<h3 class="outline_header_dice mission_header">(?P<header>.*?)</h3>'
+    r'<div class="cruMissionLegend">(?P<legend>.*?)</div><br>'
+    r'<div class="Columns2">(?P<body>.*?)</div>'
+    r'<div style="clear:both"></div>'
+    r'<div class=" img-opa"[^>]*><img border="0" src="(?P<map_src>[^"]+)"',
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _strip_tags(raw_html: str) -> str:
+    """Convert HTML fragment to plain text with simple line formatting."""
+    text = raw_html
+    replacements = {
+        "<br>": "\n",
+        "<br/>": "\n",
+        "<br />": "\n",
+        "</div>": "\n",
+        "</p>": "\n",
+        "</li>": "\n",
+        "<li>": "- ",
+        "</ul>": "\n",
+        "</h4>": "\n",
+        "</h5>": "\n",
+    }
+
+    for old, new in replacements.items():
+        text = text.replace(old, new)
+
+    text = re.sub(r"<[^>]+>", "", text)
+    text = html.unescape(text)
+    text = text.replace("\xa0", " ")
+
+    lines = [re.sub(r"\s+", " ", line).strip() for line in text.splitlines()]
+    lines = [line for line in lines if line]
+    return "\n".join(lines).strip()
+
+
+def _extract_name_and_code(header_html: str) -> Dict[str, str]:
+    """Extract mission name and D33 code from mission header block."""
+    name_match = re.search(r"</div>\s*(.*?)\s*<div style=\"float:right\">", header_html, re.DOTALL)
+    code_match = re.search(r"&nbsp;(\d+)", header_html)
+
+    mission_name = _strip_tags(name_match.group(1)) if name_match else "Unknown Mission"
+    mission_code = code_match.group(1) if code_match else "00"
+    return {"mission_name": mission_name, "mission_code": mission_code}
+
+
+def _fetch_page(url: str) -> str:
+    with urlopen(url, timeout=60) as response:
+        return response.read().decode("utf-8", errors="ignore")
+
+
+def _parse_missions(page_html: str) -> List[Dict[str, str]]:
+    records: List[Dict[str, str]] = []
+
+    for match in MISSION_BLOCK_RE.finditer(page_html):
+        header_html = match.group("header")
+        legend_html = match.group("legend")
+        body_html = match.group("body")
+        map_src = match.group("map_src")
+
+        parsed_header = _extract_name_and_code(header_html)
+        legend_text = _strip_tags(legend_html)
+        body_text = _strip_tags(body_html)
+
+        mission_text_parts = [part for part in [legend_text, body_text] if part]
+        mission_text_full = "\n\n".join(mission_text_parts).strip()
+
+        records.append(
+            {
+                "mission_name": parsed_header["mission_name"],
+                "mission_code": parsed_header["mission_code"],
+                "mission_text_full": mission_text_full,
+                "map_src": map_src,
+            }
+        )
+
+    if len(records) != 16:
+        raise RuntimeError(
+            f"Expected 16 Armageddon missions in Mission Map Key, parsed {len(records)}"
+        )
+
+    return records
+
+
+def _download_asset(map_src: str) -> str:
+    """Download map image into assets/deploys/armageddon and return relative path."""
+    ASSETS_DIR.mkdir(parents=True, exist_ok=True)
+
+    filename = Path(map_src).name
+    target = ASSETS_DIR / filename
+    source_url = urljoin(WAHAPEDIA_BASE_URL, map_src)
+
+    if not target.exists():
+        urlretrieve(source_url, target)
+
+    return f"armageddon/{filename}"
+
+
+async def run_import() -> None:
+    page_html = _fetch_page(WAHAPEDIA_URL)
+    missions = _parse_missions(page_html)
+
+    saved = 0
+    for index, mission in enumerate(missions):
+        table_prefix = "A" if index < 8 else "B"
+        mission_code = f"{table_prefix}{mission['mission_code']}"
+        asset_rel_path = _download_asset(mission["map_src"])
+
+        await sqllite_helper.upsert_static_armageddon_mission(
+            rules=RULES,
+            source=SOURCE,
+            source_url=WAHAPEDIA_URL,
+            mission_code=mission_code,
+            mission_name=mission["mission_name"],
+            mission_text_full=mission["mission_text_full"],
+            deploy_asset_path=asset_rel_path,
+            map_asset_path=asset_rel_path,
+            is_active=1,
+        )
+        saved += 1
+
+    count = await sqllite_helper.get_static_armageddon_mission_count(RULES)
+    print(f"✅ Imported/updated {saved} missions. Active static missions for {RULES}: {count}")
+
+
+if __name__ == "__main__":
+    asyncio.run(run_import())

--- a/CareBot/CareBot/migrations/028_add_static_armageddon_missions.py
+++ b/CareBot/CareBot/migrations/028_add_static_armageddon_missions.py
@@ -1,0 +1,49 @@
+"""
+Migration 028: add static Armageddon missions table.
+
+Stores imported mission texts and asset paths (relative to assets/deploys).
+"""
+from yoyo import step
+
+
+def add_static_armageddon_missions_table(conn):
+    cursor = conn.cursor()
+
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS static_armageddon_missions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            rules TEXT NOT NULL,
+            source TEXT NOT NULL,
+            source_url TEXT,
+            mission_code TEXT NOT NULL,
+            mission_name TEXT NOT NULL,
+            mission_text_full TEXT NOT NULL,
+            deploy_asset_path TEXT,
+            map_asset_path TEXT,
+            is_active INTEGER NOT NULL DEFAULT 1,
+            created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            UNIQUE(rules, source, mission_code)
+        )
+        """
+    )
+
+    cursor.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_static_armageddon_rules_active
+        ON static_armageddon_missions(rules, is_active)
+        """
+    )
+
+    cursor.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_static_armageddon_source_code
+        ON static_armageddon_missions(source, mission_code)
+        """
+    )
+
+    print("✅ static_armageddon_missions table is ready")
+
+
+steps = [step(add_static_armageddon_missions_table)]

--- a/CareBot/CareBot/mission_helper.py
+++ b/CareBot/CareBot/mission_helper.py
@@ -269,7 +269,7 @@ def generate_new_one(rules):
         return ('Only War', rules, None, f'Generic mission for {rules}', None, None)
 
 
-def _build_static_wh40k_mission_tuple(static_mission: dict) -> Tuple[str, str, None, str, None, None]:
+def _build_static_wh40k_mission_tuple(static_mission: dict) -> Tuple[str, str, None, str, Optional[str], None]:
     """Convert static Armageddon row to mission_stack tuple format."""
     mission_name = (static_mission.get('mission_name') or '').strip()
     mission_code = (static_mission.get('mission_code') or '').strip()
@@ -285,9 +285,11 @@ def _build_static_wh40k_mission_tuple(static_mission: dict) -> Tuple[str, str, N
         or "total_domination.jpg"
     )
 
-    # (deploy, rules, cell, mission_description, winner_bonus, map_description)
-    return (deploy_asset_path, "wh40k", None, description, None, None)
+    # Preserve existing WH40K mechanic: missions should have a winner bonus.
+    winner_bonus = generate_new_one("wh40k")[4]
 
+    # (deploy, rules, cell, mission_description, winner_bonus, map_description)
+    return (deploy_asset_path, "wh40k", None, description, winner_bonus, None)
 
 async def _try_create_static_wh40k_mission() -> bool:
     """Create one static WH40K mission with 50% chance if dataset is available."""

--- a/CareBot/CareBot/mission_helper.py
+++ b/CareBot/CareBot/mission_helper.py
@@ -269,6 +269,56 @@ def generate_new_one(rules):
         return ('Only War', rules, None, f'Generic mission for {rules}', None, None)
 
 
+def _build_static_wh40k_mission_tuple(static_mission: dict) -> Tuple[str, str, None, str, None, None]:
+    """Convert static Armageddon row to mission_stack tuple format."""
+    mission_name = (static_mission.get('mission_name') or '').strip()
+    mission_code = (static_mission.get('mission_code') or '').strip()
+    mission_text = (static_mission.get('mission_text_full') or '').strip()
+
+    title_parts = [part for part in [mission_name, mission_code] if part]
+    title = f"{' - '.join(title_parts)}\n\n" if title_parts else ""
+    description = (title + mission_text).strip()
+
+    deploy_asset_path = (
+        static_mission.get('deploy_asset_path')
+        or static_mission.get('map_asset_path')
+        or "total_domination.jpg"
+    )
+
+    # (deploy, rules, cell, mission_description, winner_bonus, map_description)
+    return (deploy_asset_path, "wh40k", None, description, None, None)
+
+
+async def _try_create_static_wh40k_mission() -> bool:
+    """Create one static WH40K mission with 50% chance if dataset is available."""
+    try:
+        static_count = await sqllite_helper.get_static_armageddon_mission_count("wh40k")
+    except Exception as exc:
+        logger.warning("Static mission table is unavailable, fallback to generator: %s", exc)
+        return False
+
+    if static_count <= 0:
+        return False
+
+    # 50% chance to use static mission set when no free mission exists.
+    if random.random() >= 0.5:
+        return False
+
+    static_mission = await sqllite_helper.get_random_static_armageddon_mission("wh40k")
+    if not static_mission:
+        return False
+
+    mission_tuple = _build_static_wh40k_mission_tuple(static_mission)
+    await sqllite_helper.save_mission(mission_tuple)
+
+    logger.info(
+        "Created static WH40K mission from Armageddon dataset: %s (%s)",
+        static_mission.get('mission_name'),
+        static_mission.get('mission_code'),
+    )
+    return True
+
+
 async def ensure_mission_cell(mission_id: int, attacker_id: Optional[str], defender_id: Optional[str]):
     """Assign a mission cell using attacker/defender alliances if it is still missing."""
     mission = await sqllite_helper.get_mission_details(mission_id)
@@ -342,9 +392,18 @@ async def get_mission(rules: Optional[str], attacker_id: Optional[str] = None, d
     mission = await sqllite_helper.get_mission(rules)
     
     if not mission:
-        # Generate new mission (returns tuple)
-        mission_tuple = generate_new_one(rules)
-        await sqllite_helper.save_mission(mission_tuple)
+        static_created = False
+        if rules == "wh40k":
+            try:
+                static_created = await _try_create_static_wh40k_mission()
+            except Exception as exc:
+                logger.warning("Failed to create static WH40K mission, using generator: %s", exc)
+
+        if not static_created:
+            # Generate new mission (returns tuple)
+            mission_tuple = generate_new_one(rules)
+            await sqllite_helper.save_mission(mission_tuple)
+
         # Re-fetch from DB to get Mission object with ID
         mission = await sqllite_helper.get_mission(rules)
         

--- a/CareBot/CareBot/mock_sqlite_helper.py
+++ b/CareBot/CareBot/mock_sqlite_helper.py
@@ -47,6 +47,7 @@ MOCK_WARMASTERS = {
 }
 
 MOCK_MISSIONS = {}
+MOCK_STATIC_ARMAGEDDON_MISSIONS = {}
 MOCK_BATTLES = {}
 MOCK_BATTLE_ATTENDERS = {}
 MOCK_PENDING_RESULTS = {}
@@ -748,6 +749,59 @@ async def get_mission(rules):
             )
 
     return None
+
+
+async def upsert_static_armageddon_mission(
+    rules,
+    source,
+    source_url,
+    mission_code,
+    mission_name,
+    mission_text_full,
+    deploy_asset_path,
+    map_asset_path,
+    is_active=1,
+):
+    """Mock upsert for static armageddon missions."""
+    print(
+        "🧪 Mock: upsert_static_armageddon_mission("
+        f"{rules}, {source}, {mission_code}, {mission_name})"
+    )
+    key = (rules, source, mission_code)
+    MOCK_STATIC_ARMAGEDDON_MISSIONS[key] = {
+        'rules': rules,
+        'source': source,
+        'source_url': source_url,
+        'mission_code': mission_code,
+        'mission_name': mission_name,
+        'mission_text_full': mission_text_full,
+        'deploy_asset_path': deploy_asset_path,
+        'map_asset_path': map_asset_path,
+        'is_active': int(is_active),
+    }
+    return True
+
+
+async def get_static_armageddon_mission_count(rules='wh40k'):
+    """Mock count of active static armageddon missions."""
+    print(f"🧪 Mock: get_static_armageddon_mission_count({rules})")
+    count = 0
+    for mission in MOCK_STATIC_ARMAGEDDON_MISSIONS.values():
+        if mission.get('rules') == rules and int(mission.get('is_active', 0)) == 1:
+            count += 1
+    return count
+
+
+async def get_random_static_armageddon_mission(rules='wh40k'):
+    """Mock random static armageddon mission selection."""
+    print(f"🧪 Mock: get_random_static_armageddon_mission({rules})")
+    candidates = [
+        mission for mission in MOCK_STATIC_ARMAGEDDON_MISSIONS.values()
+        if mission.get('rules') == rules and int(mission.get('is_active', 0)) == 1
+    ]
+    if not candidates:
+        return None
+    return random.choice(candidates)
 
 async def get_schedule_by_user(user_telegram, date=None):
     print(f"🧪 Mock: get_schedule_by_user({user_telegram}, {date})")

--- a/CareBot/CareBot/sqllite_helper.py
+++ b/CareBot/CareBot/sqllite_helper.py
@@ -9,7 +9,7 @@ import aiosqlite
 import os
 import random
 import logging
-from typing import List, Dict, Optional
+from typing import List, Dict, Optional, Any
 from models import Mission, Battle, MissionDetails, Warmaster, Alliance, MapCell, PendingResult
 
 logger = logging.getLogger(__name__)
@@ -822,6 +822,87 @@ async def save_mission(mission):
               mission[5] if len(mission) > 5 else None,
               mission[6] if len(mission) > 6 else None))
         await db.commit()
+
+
+async def upsert_static_armageddon_mission(
+    rules: str,
+    source: str,
+    source_url: str,
+    mission_code: str,
+    mission_name: str,
+    mission_text_full: str,
+    deploy_asset_path: Optional[str],
+    map_asset_path: Optional[str],
+    is_active: int = 1,
+):
+    """Insert or update one static Armageddon mission record."""
+    async with aiosqlite.connect(DATABASE_PATH) as db:
+        await db.execute(
+            '''
+            INSERT INTO static_armageddon_missions(
+                rules, source, source_url, mission_code, mission_name,
+                mission_text_full, deploy_asset_path, map_asset_path,
+                is_active, created_at, updated_at
+            )
+            VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+            ON CONFLICT(rules, source, mission_code)
+            DO UPDATE SET
+                source_url = excluded.source_url,
+                mission_name = excluded.mission_name,
+                mission_text_full = excluded.mission_text_full,
+                deploy_asset_path = excluded.deploy_asset_path,
+                map_asset_path = excluded.map_asset_path,
+                is_active = excluded.is_active,
+                updated_at = CURRENT_TIMESTAMP
+            ''',
+            (
+                rules,
+                source,
+                source_url,
+                mission_code,
+                mission_name,
+                mission_text_full,
+                deploy_asset_path,
+                map_asset_path,
+                is_active,
+            ),
+        )
+        await db.commit()
+
+
+async def get_static_armageddon_mission_count(rules: str = "wh40k") -> int:
+    """Return number of active static Armageddon missions for given rules."""
+    async with aiosqlite.connect(DATABASE_PATH) as db:
+        async with db.execute(
+            '''
+            SELECT COUNT(*)
+            FROM static_armageddon_missions
+            WHERE rules = ? AND is_active = 1
+            ''',
+            (rules,),
+        ) as cursor:
+            row = await cursor.fetchone()
+            return row[0] if row else 0
+
+
+async def get_random_static_armageddon_mission(rules: str = "wh40k") -> Optional[Dict[str, Any]]:
+    """Return one random active static Armageddon mission record."""
+    async with aiosqlite.connect(DATABASE_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute(
+            '''
+            SELECT id, rules, source, source_url, mission_code,
+                   mission_name, mission_text_full, deploy_asset_path,
+                   map_asset_path, is_active
+            FROM static_armageddon_missions
+            WHERE rules = ? AND is_active = 1
+            ORDER BY RANDOM()
+            LIMIT 1
+            ''',
+            (rules,),
+        ) as cursor:
+            row = await cursor.fetchone()
+            return dict(row) if row else None
 
 
 async def set_nickname(user_telegram_id, nickname):

--- a/CareBot/CareBot/views.py
+++ b/CareBot/CareBot/views.py
@@ -227,7 +227,11 @@ def create_battle():
                     )
             else:
                 # --- Auto-generate mission from rules ---
-                mission_data = await mission_helper.get_mission(rules_raw)
+                try:
+                    mission_data = await mission_helper.get_mission(rules_raw)
+                except Exception:
+                    logger.error('Web UI: mission generation failed (rules=%s)', rules_raw, exc_info=True)
+                    return _api_error('mission_gen_failed', 'Не удалось создать миссию. Попробуйте ещё раз.', 500)
                 if not mission_data:
                     return _api_error('mission_gen_failed', 'Не удалось создать миссию. Попробуйте ещё раз.', 500)
 

--- a/CareBot/CareBot/views.py
+++ b/CareBot/CareBot/views.py
@@ -227,12 +227,15 @@ def create_battle():
                     )
             else:
                 # --- Auto-generate mission from rules ---
-                mission_tuple = mission_helper.generate_new_one(rules_raw)
-                await sqllite_helper.save_mission(mission_tuple)
-                new_mission = await sqllite_helper.get_mission(rules_raw)
-                if not new_mission:
+                mission_data = await mission_helper.get_mission(rules_raw)
+                if not mission_data:
                     return _api_error('mission_gen_failed', 'Не удалось создать миссию. Попробуйте ещё раз.', 500)
-                selected_mission_id = new_mission.id
+
+                # Backward-compatible tuple format: (deploy, rules, cell, description, id, winner_bonus)
+                mission_id_raw = mission_data[4] if len(mission_data) > 4 else None
+                if mission_id_raw in (None, ''):
+                    return _api_error('mission_gen_failed', 'Не удалось определить mission_id для созданной миссии.', 500)
+                selected_mission_id = int(mission_id_raw)
                 logger.info('Web UI: auto-generated mission %s (rules=%s)', selected_mission_id, rules_raw)
 
             p1_id = str(participant_1_id)

--- a/CareBot/tests/test_static_wh40k_mission.py
+++ b/CareBot/tests/test_static_wh40k_mission.py
@@ -1,0 +1,281 @@
+"""
+Tests for static WH40K mission selection logic in mission_helper.py.
+
+Covers:
+- Static dataset path is used when available (50% chance path)
+- Fallback to generator when static table is unavailable (exception)
+- Fallback to generator when static dataset is empty (count == 0)
+- Winner bonus and deploy asset path handling for static missions
+"""
+import os
+import sys
+import asyncio
+import types
+
+MODULE_DIR = os.path.join(os.path.dirname(__file__), '..', 'CareBot')
+sys.path.insert(0, os.path.abspath(MODULE_DIR))
+
+os.environ['CAREBOT_TEST_MODE'] = 'true'
+sys.modules.setdefault("config", types.SimpleNamespace(TEST_MODE=True))
+
+import mission_helper  # noqa: E402
+import mock_sqlite_helper  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Tests for _build_static_wh40k_mission_tuple
+# ---------------------------------------------------------------------------
+
+def test_build_static_wh40k_mission_tuple_winner_bonus_populated():
+    """Static mission tuples must always carry a non-None winner bonus."""
+    static_mission = {
+        'mission_name': 'Armageddon Strike',
+        'mission_code': 'ARM-01',
+        'mission_text_full': 'Hold the line at all costs.',
+        'deploy_asset_path': 'custom_deploy.jpg',
+    }
+    result = mission_helper._build_static_wh40k_mission_tuple(static_mission)
+    # Tuple: (deploy, rules, cell, description, winner_bonus, map_description)
+    winner_bonus = result[4]
+    assert winner_bonus is not None, "Winner bonus must be populated for static WH40K missions"
+    assert isinstance(winner_bonus, str) and len(winner_bonus) > 0
+
+
+def test_build_static_wh40k_mission_tuple_uses_deploy_asset_path():
+    """deploy_asset_path field should be preferred for the deploy image."""
+    static_mission = {
+        'mission_name': 'Strike',
+        'mission_code': 'S-01',
+        'mission_text_full': 'Mission text.',
+        'deploy_asset_path': 'my_deploy.jpg',
+        'map_asset_path': 'my_map.jpg',
+    }
+    result = mission_helper._build_static_wh40k_mission_tuple(static_mission)
+    assert result[0] == 'my_deploy.jpg'
+
+
+def test_build_static_wh40k_mission_tuple_falls_back_to_map_asset():
+    """map_asset_path should be used when deploy_asset_path is absent."""
+    static_mission = {
+        'mission_name': 'Strike',
+        'mission_code': 'S-01',
+        'mission_text_full': 'Mission text.',
+        'deploy_asset_path': None,
+        'map_asset_path': 'fallback_map.jpg',
+    }
+    result = mission_helper._build_static_wh40k_mission_tuple(static_mission)
+    assert result[0] == 'fallback_map.jpg'
+
+
+def test_build_static_wh40k_mission_tuple_default_deploy_when_no_asset():
+    """Default deploy image is used when both asset fields are absent/None."""
+    static_mission = {
+        'mission_name': 'Strike',
+        'mission_code': 'S-01',
+        'mission_text_full': 'Mission text.',
+    }
+    result = mission_helper._build_static_wh40k_mission_tuple(static_mission)
+    assert result[0] == 'total_domination.jpg'
+
+
+def test_build_static_wh40k_mission_tuple_rules_and_cell():
+    """Rules must be 'wh40k' and cell must be None for static missions."""
+    static_mission = {
+        'mission_name': 'Strike',
+        'mission_code': 'S-01',
+        'mission_text_full': 'Mission text.',
+    }
+    result = mission_helper._build_static_wh40k_mission_tuple(static_mission)
+    assert result[1] == 'wh40k'
+    assert result[2] is None   # cell
+    assert result[5] is None   # map_description
+
+
+def test_build_static_wh40k_mission_tuple_description_format():
+    """Description must include the mission name and code as a title."""
+    static_mission = {
+        'mission_name': 'Total War',
+        'mission_code': 'TW-42',
+        'mission_text_full': 'Fight until the last.',
+    }
+    result = mission_helper._build_static_wh40k_mission_tuple(static_mission)
+    description = result[3]
+    assert 'Total War' in description
+    assert 'TW-42' in description
+    assert 'Fight until the last.' in description
+
+
+# ---------------------------------------------------------------------------
+# Tests for _try_create_static_wh40k_mission
+# ---------------------------------------------------------------------------
+
+def test_try_create_static_wh40k_mission_uses_static_when_available(monkeypatch):
+    """Static mission is created when dataset is non-empty and random favours it."""
+    static_row = {
+        'mission_name': 'Armageddon',
+        'mission_code': 'ARM-01',
+        'mission_text_full': 'Hold the line.',
+        'deploy_asset_path': 'arm_deploy.jpg',
+    }
+    saved = []
+
+    async def fake_count(rules):
+        return 5
+
+    async def fake_random_mission(rules):
+        return static_row
+
+    async def fake_save(mission_tuple):
+        saved.append(mission_tuple)
+
+    monkeypatch.setattr(mission_helper.sqllite_helper, 'get_static_armageddon_mission_count', fake_count)
+    monkeypatch.setattr(mission_helper.sqllite_helper, 'get_random_static_armageddon_mission', fake_random_mission)
+    monkeypatch.setattr(mission_helper.sqllite_helper, 'save_mission', fake_save)
+    # Force random.random() to return a value < 0.5 so the static path is taken
+    monkeypatch.setattr(mission_helper.random, 'random', lambda: 0.1)
+
+    result = asyncio.run(mission_helper._try_create_static_wh40k_mission())
+
+    assert result is True
+    assert len(saved) == 1
+    # Saved tuple must have winner_bonus populated
+    assert saved[0][4] is not None
+
+
+def test_try_create_static_wh40k_mission_skips_when_random_high(monkeypatch):
+    """When random >= 0.5 the static path should be skipped (returns False)."""
+    async def fake_count(rules):
+        return 5
+
+    monkeypatch.setattr(mission_helper.sqllite_helper, 'get_static_armageddon_mission_count', fake_count)
+    # Force random to return >= 0.5
+    monkeypatch.setattr(mission_helper.random, 'random', lambda: 0.9)
+
+    result = asyncio.run(mission_helper._try_create_static_wh40k_mission())
+
+    assert result is False
+
+
+def test_try_create_static_wh40k_mission_fallback_on_table_unavailable(monkeypatch):
+    """Exception from count query causes graceful fallback (returns False)."""
+    async def fake_count(rules):
+        raise RuntimeError("table armageddon_static_missions does not exist")
+
+    monkeypatch.setattr(mission_helper.sqllite_helper, 'get_static_armageddon_mission_count', fake_count)
+
+    result = asyncio.run(mission_helper._try_create_static_wh40k_mission())
+
+    assert result is False
+
+
+def test_try_create_static_wh40k_mission_fallback_when_empty(monkeypatch):
+    """When count == 0 the static path should be skipped (returns False)."""
+    async def fake_count(rules):
+        return 0
+
+    monkeypatch.setattr(mission_helper.sqllite_helper, 'get_static_armageddon_mission_count', fake_count)
+
+    result = asyncio.run(mission_helper._try_create_static_wh40k_mission())
+
+    assert result is False
+
+
+def test_try_create_static_wh40k_mission_fallback_when_no_row_returned(monkeypatch):
+    """When get_random_static_armageddon_mission returns None, return False."""
+    async def fake_count(rules):
+        return 3
+
+    async def fake_random_mission(rules):
+        return None
+
+    monkeypatch.setattr(mission_helper.sqllite_helper, 'get_static_armageddon_mission_count', fake_count)
+    monkeypatch.setattr(mission_helper.sqllite_helper, 'get_random_static_armageddon_mission', fake_random_mission)
+    monkeypatch.setattr(mission_helper.random, 'random', lambda: 0.1)
+
+    result = asyncio.run(mission_helper._try_create_static_wh40k_mission())
+
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Integration: get_mission uses static path vs generator
+# ---------------------------------------------------------------------------
+
+class _FakeMission:
+    """Minimal Mission-like object returned by sqllite_helper.get_mission."""
+    def __init__(self):
+        self.id = 99
+        self.deploy = 'arm_deploy.jpg'
+        self.rules = 'wh40k'
+        self.cell = None
+        self.mission_description = 'Armageddon mission'
+        self.winner_bonus = 'Some bonus'
+        self.status = 0
+        self.created_date = '2025-01-01'
+        self.map_description = None
+        self.reward_config = None
+
+    def to_tuple(self):
+        return (self.deploy, self.rules, self.cell, self.mission_description, self.id, self.winner_bonus)
+
+
+def test_get_mission_uses_static_path_when_available(monkeypatch):
+    """get_mission creates a static mission when static data is available."""
+    static_created_flag = []
+
+    async def fake_get_mission_first_call(rules):
+        # First call returns None (no existing mission), subsequent calls return one
+        if not static_created_flag:
+            return None
+        return _FakeMission()
+
+    async def fake_try_create_static():
+        static_created_flag.append(True)
+        return True
+
+    async def fake_ensure_cell(mission_id, attacker_id, defender_id):
+        return None
+
+    monkeypatch.setattr(mission_helper.sqllite_helper, 'get_mission', fake_get_mission_first_call)
+    monkeypatch.setattr(mission_helper, '_try_create_static_wh40k_mission', fake_try_create_static)
+    monkeypatch.setattr(mission_helper, 'ensure_mission_cell', fake_ensure_cell)
+
+    result = asyncio.run(mission_helper.get_mission('wh40k'))
+
+    assert static_created_flag, "_try_create_static_wh40k_mission should have been called"
+    assert result is not None
+
+
+def test_get_mission_uses_generator_when_static_unavailable(monkeypatch):
+    """get_mission falls back to generate_new_one when static creation fails."""
+    generator_called = []
+    saved = []
+
+    async def fake_get_mission(rules):
+        if not saved:
+            return None
+        return _FakeMission()
+
+    async def fake_try_create_static():
+        return False  # static path not taken
+
+    def fake_generate_new_one(rules):
+        generator_called.append(rules)
+        return ('deploy.jpg', rules, None, 'Generated mission', 'Winner bonus', None)
+
+    async def fake_save_mission(mission_tuple):
+        saved.append(mission_tuple)
+
+    async def fake_ensure_cell(mission_id, attacker_id, defender_id):
+        return None
+
+    monkeypatch.setattr(mission_helper.sqllite_helper, 'get_mission', fake_get_mission)
+    monkeypatch.setattr(mission_helper, '_try_create_static_wh40k_mission', fake_try_create_static)
+    monkeypatch.setattr(mission_helper, 'generate_new_one', fake_generate_new_one)
+    monkeypatch.setattr(mission_helper.sqllite_helper, 'save_mission', fake_save_mission)
+    monkeypatch.setattr(mission_helper, 'ensure_mission_cell', fake_ensure_cell)
+
+    result = asyncio.run(mission_helper.get_mission('wh40k'))
+
+    assert generator_called, "generate_new_one should have been called as fallback"
+    assert result is not None

--- a/scripts/update-production.ps1
+++ b/scripts/update-production.ps1
@@ -46,32 +46,22 @@ function Build-ProductionImage {
 # Safely stop and remove old container
 function Stop-OldContainer {
     Write-Info "Safely stopping old container..."
-    
-    # Check if container exists
-    $containerExists = ssh $SERVER_HOST "docker ps -a --filter 'name=carebot_production' --format '{{.Names}}' | grep -c carebot_production 2>/dev/null || echo '0'"
-    
-    if ($containerExists -eq "0" -or $null -eq $containerExists) {
+
+    $containerId = ssh $SERVER_HOST "docker ps -aq --filter 'name=^/carebot_production$'"
+
+    if (-not $containerId) {
         Write-Info "No old container found, skipping stop"
         return $true
     }
-    
-    # Check container status
-    $status = ssh $SERVER_HOST "docker ps --all --filter 'name=carebot_production' --format '{{.State}}' 2>/dev/null || echo 'not-found'"
-    
-    if ($status -eq "running") {
-        Write-Info "Container is running, stopping..."
-        ssh $SERVER_HOST "docker stop carebot_production --time=30 2>&1"
-        Start-Sleep -Seconds 2
-    }
-    
-    # Remove the container
-    Write-Info "Removing old container..."
-    ssh $SERVER_HOST "docker rm carebot_production 2>&1"
-    
+
+    Write-Info "Removing existing container ID: $containerId"
+    ssh $SERVER_HOST "docker rm -f $containerId 2>&1"
+
     if ($LASTEXITCODE -ne 0) {
-        Write-Warning "Failed to remove container (may not exist), continuing..."
+        Write-Error "Failed to remove existing container: $containerId"
+        return $false
     }
-    
+
     Write-Success "Old container cleaned up"
     return $true
 }
@@ -133,52 +123,37 @@ function Test-Token {
 function Sync-Files {
     Write-Info "Syncing files to server..."
     
-    $filesToSync = @(
-        "CareBot/CareBot/handlers.py",
-        "CareBot/CareBot/views.py",
-        "CareBot/CareBot/map_export_service.py",
-        "CareBot/CareBot/warmaster_helper.py", 
-        "CareBot/CareBot/settings_helper.py",
-        "CareBot/CareBot/schedule_helper.py",
-        "CareBot/CareBot/mission_helper.py",
-        "CareBot/CareBot/features.py",
-        "CareBot/CareBot/register_features.py",
-        "CareBot/CareBot/common_resource_feature.py",
-        "CareBot/CareBot/players_helper.py",
-        "CareBot/CareBot/map_helper.py",
-        "CareBot/CareBot/map_exporter.py",
-        "CareBot/CareBot/sqllite_helper.py",
-        "CareBot/CareBot/models.py",
-        "CareBot/CareBot/mission_message_builder.py",
-        "CareBot/CareBot/feature_flags_helper.py",
-        "CareBot/CareBot/keyboard_constructor.py",
-        "CareBot/CareBot/localization.py",
-        "CareBot/CareBot/notification_service.py",
-        "CareBot/CareBot/migrate_db.py",
-        "CareBot/CareBot/config.py",
-        "CareBot/CareBot/templates/battles.html",
-        "CareBot/run_hybrid.py",
-        "CareBot/requirements.txt",
+    # Синхронизируем инфраструктурные файлы
+    $infraFiles = @(
         "Dockerfile",
         "entrypoint.sh",
-        "docker-compose.production.yml"
+        "docker-compose.production.yml",
+        "CareBot/requirements.txt",
+        "CareBot/run_hybrid.py",
+        "CareBot/run_bot.py",
+        "CareBot/runserver.py"
     )
-    
-    # Синхронизируем основные файлы
-    foreach ($file in $filesToSync) {
+
+    foreach ($file in $infraFiles) {
         if (Test-Path $file) {
             Write-Host "  Copying $file..."
-            
+
             $remoteDir = Split-Path $file -Parent
             if ($remoteDir) {
                 ssh $SERVER_HOST "mkdir -p $PRODUCTION_PATH/$remoteDir"
             }
-            
+
             scp $file "${SERVER_HOST}:${PRODUCTION_PATH}/$file"
         } else {
             Write-Warning "File $file not found, skipping"
         }
     }
+
+    # Синхронизируем весь пакет приложения рекурсивно,
+    # чтобы новые модули автоматически попадали в production build context.
+    Write-Info "Syncing full CareBot application package..."
+    ssh $SERVER_HOST "mkdir -p $PRODUCTION_PATH/CareBot"
+    scp -r "CareBot/CareBot" "${SERVER_HOST}:${PRODUCTION_PATH}/CareBot/"
     
     # Синхронизируем миграции в отдельную папку
     Write-Info "Syncing migrations to separate directory..."
@@ -190,16 +165,6 @@ function Sync-Files {
         scp "CareBot/CareBot/migrations/$($migration.Name)" "${SERVER_HOST}:${PRODUCTION_PATH}/migrations/$($migration.Name)"
     }
 
-    # Синхронизируем assets для деплоев WH40K
-    Write-Info "Syncing WH40K deploy assets..."
-    ssh $SERVER_HOST "mkdir -p $PRODUCTION_PATH/CareBot/CareBot/assets/deploys"
-
-    $deployAssetFiles = Get-ChildItem -Path "CareBot/CareBot/assets/deploys" -File -ErrorAction SilentlyContinue
-    foreach ($asset in $deployAssetFiles) {
-        Write-Host "  Copying deploy asset: $($asset.Name)..."
-        scp "CareBot/CareBot/assets/deploys/$($asset.Name)" "${SERVER_HOST}:${PRODUCTION_PATH}/CareBot/CareBot/assets/deploys/$($asset.Name)"
-    }
-    
     Write-Success "File sync completed"
     return $true
 }
@@ -211,7 +176,7 @@ function Test-Health {
     Start-Sleep -Seconds 10
     
     try {
-        $response = Invoke-WebRequest -Uri $HEALTH_URL -Method GET -TimeoutSec 10 -Proxy $null
+        $response = Invoke-WebRequest -Uri $HEALTH_URL -Method GET -TimeoutSec 10 -Proxy $null -UseBasicParsing
         
         if ($response.StatusCode -eq 200) {
             $healthData = $response.Content | ConvertFrom-Json

--- a/scripts/wsl2-deploy.ps1
+++ b/scripts/wsl2-deploy.ps1
@@ -36,6 +36,15 @@ function Write-Error($text) { Write-Host "ERROR: $text" -ForegroundColor Red }
 function Write-Info($text) { Write-Host "INFO: $text" -ForegroundColor Cyan }
 function Write-Warning($text) { Write-Host "WARNING: $text" -ForegroundColor Yellow }
 
+function Invoke-WSLCommand {
+    param(
+        [string]$Command,
+        [string]$WorkingDirectory = "/"
+    )
+
+    & wsl -d $WSL_DISTRO --cd $WorkingDirectory /bin/sh -lc $Command
+}
+
 # Run external command with spinner and optional timeout
 function Invoke-ExternalWithProgress {
     param(
@@ -47,8 +56,8 @@ function Invoke-ExternalWithProgress {
     )
 
     $job = Start-Job -ScriptBlock {
-        param($exe, $args)
-        $output = & $exe @args 2>&1
+        param($exe, $cmdArgs)
+        $output = & $exe @cmdArgs 2>&1
         $exitCode = $LASTEXITCODE
         [pscustomobject]@{ Output = $output; ExitCode = $exitCode }
     } -ArgumentList $FilePath, $Arguments
@@ -120,7 +129,7 @@ function Test-WSL2 {
 function Test-DockerWSL {
     Write-Info "Checking Docker in WSL2..."
     
-    $result = wsl -d $WSL_DISTRO -e bash -c "docker --version" 2>&1
+    $result = Invoke-WSLCommand -Command "docker --version" 2>&1
     
     if ($LASTEXITCODE -ne 0) {
         Write-Error "Docker not installed in WSL2"
@@ -134,10 +143,10 @@ function Test-DockerWSL {
     Write-Success "Docker is available: $result"
 
     # Check if Docker daemon is running and accessible without sudo
-    $dockerInfo = wsl -d $WSL_DISTRO -e bash -c "docker info" 2>&1
+    $dockerInfo = Invoke-WSLCommand -Command "docker info" 2>&1
     if ($LASTEXITCODE -ne 0) {
         Write-Error "Docker daemon is not running or permission denied"
-        Write-Info "If needed, start it manually: wsl -d $WSL_DISTRO -e bash -lc 'sudo service docker start'"
+        Write-Info "If needed, start it manually: wsl -d $WSL_DISTRO --cd / /bin/sh -lc 'sudo service docker start'"
         Write-Info "If permission denied, add user to docker group and restart WSL"
         return $false
     }
@@ -207,8 +216,8 @@ function Build-Image {
     
     Write-Info "Executing: $buildCmd"
     
-    $ok = Invoke-ExternalWithProgress -FilePath "wsl" -Arguments @("-d", $WSL_DISTRO, "-e", "bash", "-c", $buildCmd) -Activity "Building Docker image" -TimeoutSec $TIMEOUT_BUILD_SEC
-    if (-not $ok) { return $false }
+    Invoke-WSLCommand -Command $buildCmd
+    if ($LASTEXITCODE -ne 0) { return $false }
     
     if ($LASTEXITCODE -eq 0) {
         Write-Success "Image built successfully: ${IMAGE_NAME}:${Tag}"
@@ -226,10 +235,10 @@ function Show-ImageInspect {
     if (-not (Test-DockerWSL)) { return }
     
     Write-Info "Image details:"
-    wsl -d $WSL_DISTRO -e bash -c "docker images ${IMAGE_NAME}:${Tag}"
+    Invoke-WSLCommand -Command "docker images ${IMAGE_NAME}:${Tag}"
     
     Write-Info "`nListing files in image /app/CareBot/:"
-    wsl -d $WSL_DISTRO -e bash -c "docker run --rm ${IMAGE_NAME}:${Tag} ls -lah /app/CareBot/"
+    Invoke-WSLCommand -Command "docker run --rm ${IMAGE_NAME}:${Tag} ls -lah /app/CareBot/"
     
     Write-Info "`nChecking key files:"
     $keyFiles = @(
@@ -241,7 +250,7 @@ function Show-ImageInspect {
     )
     
     foreach ($file in $keyFiles) {
-        $exists = wsl -d $WSL_DISTRO -e bash -c "docker run --rm ${IMAGE_NAME}:${Tag} test -f $file && echo 'EXISTS' || echo 'MISSING'"
+        $exists = Invoke-WSLCommand -Command "docker run --rm ${IMAGE_NAME}:${Tag} test -f $file && echo 'EXISTS' || echo 'MISSING'"
         if ($exists -match "EXISTS") {
             Write-Success "$file - EXISTS"
         } else {
@@ -250,13 +259,13 @@ function Show-ImageInspect {
     }
     
     Write-Info "`nEnvironment variables:"
-    wsl -d $WSL_DISTRO -e bash -c "docker inspect ${IMAGE_NAME}:${Tag} --format='{{.Config.Env}}'"
+    Invoke-WSLCommand -Command "docker inspect ${IMAGE_NAME}:${Tag} --format='{{.Config.Env}}'"
     
     Write-Info "`nExposed ports:"
-    wsl -d $WSL_DISTRO -e bash -c "docker inspect ${IMAGE_NAME}:${Tag} --format='{{.Config.ExposedPorts}}'"
+    Invoke-WSLCommand -Command "docker inspect ${IMAGE_NAME}:${Tag} --format='{{.Config.ExposedPorts}}'"
     
     Write-Info "`nImage layers:"
-    wsl -d $WSL_DISTRO -e bash -c "docker history ${IMAGE_NAME}:${Tag}"
+    Invoke-WSLCommand -Command "docker history ${IMAGE_NAME}:${Tag}"
 }
 
 # Test image locally
@@ -268,8 +277,8 @@ function Test-ImageLocally {
     
     # Stop existing test container
     Write-Info "Stopping existing test container..."
-    wsl -d $WSL_DISTRO -e bash -c "docker stop carebot_test 2>/dev/null || true"
-    wsl -d $WSL_DISTRO -e bash -c "docker rm carebot_test 2>/dev/null || true"
+    Invoke-WSLCommand -Command "docker stop carebot_test 2>/dev/null || true"
+    Invoke-WSLCommand -Command "docker rm carebot_test 2>/dev/null || true"
     
     # Get token
     $token = Get-Content $LOCAL_ENV_FILE | Where-Object { $_ -match "TELEGRAM_BOT_TOKEN=" } | ForEach-Object { $_.Split('=')[1] }
@@ -294,7 +303,7 @@ function Test-ImageLocally {
               "-e SERVER_PORT='5555' " +
               "${IMAGE_NAME}:${Tag}"
     
-    wsl -d $WSL_DISTRO -e bash -c $runCmd
+    Invoke-WSLCommand -Command $runCmd
     
     if ($LASTEXITCODE -ne 0) {
         Write-Error "Failed to start test container"
@@ -305,11 +314,11 @@ function Test-ImageLocally {
     Start-Sleep -Seconds 10
     
     Write-Info "Container logs:"
-    wsl -d $WSL_DISTRO -e bash -c "docker logs carebot_test --tail=20"
+    Invoke-WSLCommand -Command "docker logs carebot_test --tail=20"
     
     Write-Info "`nTesting health endpoint..."
     try {
-        $response = Invoke-WebRequest -Uri $LOCAL_HEALTH_URL -Method GET -TimeoutSec 10
+        $response = Invoke-WebRequest -Uri $LOCAL_HEALTH_URL -Method GET -TimeoutSec 10 -UseBasicParsing
         if ($response.StatusCode -eq 200) {
             Write-Success "Health check passed!"
             Write-Info "Response: $($response.Content)"
@@ -320,7 +329,7 @@ function Test-ImageLocally {
     }
     catch {
         Write-Error "Health check failed: $($_.Exception.Message)"
-        Write-Info "Check logs: wsl -d $WSL_DISTRO -e bash -c 'docker logs carebot_test'"
+        Write-Info "Check logs: wsl -d $WSL_DISTRO --cd / /bin/sh -lc 'docker logs carebot_test'"
         return $false
     }
 }
@@ -328,8 +337,8 @@ function Test-ImageLocally {
 # Stop test container
 function Stop-TestContainer {
     Write-Info "Stopping test container..."
-    wsl -d $WSL_DISTRO -e bash -c "docker stop carebot_test 2>/dev/null || true"
-    wsl -d $WSL_DISTRO -e bash -c "docker rm carebot_test 2>/dev/null || true"
+    Invoke-WSLCommand -Command "docker stop carebot_test 2>/dev/null || true"
+    Invoke-WSLCommand -Command "docker rm carebot_test 2>/dev/null || true"
     Write-Success "Test container stopped"
 }
 
@@ -342,8 +351,8 @@ function Save-Image {
     $outputPathWSL = $OutputPath -replace '\\', '/' -replace 'C:', '/mnt/c' -replace 'c:', '/mnt/c'
     
     Write-Info "Saving ${IMAGE_NAME}:${Tag} to $OutputPath..."
-    $ok = Invoke-ExternalWithProgress -FilePath "wsl" -Arguments @("-d", $WSL_DISTRO, "-e", "bash", "-c", "docker save ${IMAGE_NAME}:${Tag} -o '$outputPathWSL'") -Activity "Saving Docker image" -TimeoutSec $TIMEOUT_SAVE_SEC
-    if (-not $ok) { return $false }
+    Invoke-WSLCommand -Command "docker save ${IMAGE_NAME}:${Tag} -o '$outputPathWSL'"
+    if ($LASTEXITCODE -ne 0) { return $false }
     
     if ($LASTEXITCODE -eq 0) {
         $fileSize = (Get-Item $OutputPath).Length / 1MB
@@ -408,6 +417,27 @@ function Transfer-Image {
 }
 
 # Deploy to production
+function Remove-ConflictingProductionContainer {
+    Write-Info "Removing any existing production container outside compose..."
+
+    $containerId = ssh $SERVER_HOST "docker ps -aq --filter 'name=^/${CONTAINER_NAME}$'"
+    if (-not $containerId) {
+        Write-Info "No conflicting production container found"
+        return $true
+    }
+
+    Write-Info "Removing existing container ID: $containerId"
+    ssh $SERVER_HOST "docker rm -f $containerId"
+
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to remove existing production container: $containerId"
+        return $false
+    }
+
+    Write-Success "Existing production container removed"
+    return $true
+}
+
 function Deploy-Production {
     Write-Info "Deploying to production..."
     
@@ -429,6 +459,8 @@ function Deploy-Production {
 
     # Update image tag in production .env
     Set-ProductionImageTag -ImageTag $Tag
+
+    if (-not (Remove-ConflictingProductionContainer)) { return $false }
     
     # Restart production container with new image
     Write-Info "Restarting production container..."
@@ -472,7 +504,7 @@ function Set-ProductionImageTag {
 
     Write-Info "Setting production image tag to $ImageTag..."
     ssh $SERVER_HOST "mkdir -p $PRODUCTION_PATH"
-    ssh $SERVER_HOST "cd $PRODUCTION_PATH && if [ -f .env ]; then sed -i '/^CAREBOT_IMAGE_TAG=/d' .env; fi; echo \"CAREBOT_IMAGE_TAG=$ImageTag\" >> .env"
+    ssh $SERVER_HOST "cd $PRODUCTION_PATH && if [ -f .env ]; then sed -i '/CAREBOT_IMAGE_TAG=/d' .env; fi; printf '\n%s\n' 'CAREBOT_IMAGE_TAG=$ImageTag' >> .env"
     Write-Success "Production image tag set"
 }
 
@@ -483,7 +515,7 @@ function Test-ProductionHealth {
     Start-Sleep -Seconds 5
     
     try {
-        $response = Invoke-WebRequest -Uri $HEALTH_URL -Method GET -TimeoutSec 10
+        $response = Invoke-WebRequest -Uri $HEALTH_URL -Method GET -TimeoutSec 10 -UseBasicParsing
         
         if ($response.StatusCode -eq 200) {
             $healthData = $response.Content | ConvertFrom-Json
@@ -513,7 +545,7 @@ function Create-Backup {
 # List images
 function Show-Images {
     Write-Info "Docker images in WSL2:"
-    wsl -d $WSL_DISTRO -e bash -c "docker images | grep -E '(REPOSITORY|carebot)'"
+    Invoke-WSLCommand -Command "docker images | grep -E '(REPOSITORY|carebot)'"
 }
 
 # Cleanup old images
@@ -521,10 +553,10 @@ function Clean-Images {
     Write-Info "Cleaning up old Docker images..."
     
     # Remove dangling images
-    wsl -d $WSL_DISTRO -e bash -c "docker image prune -f"
+    Invoke-WSLCommand -Command "docker image prune -f"
     
     # Remove old carebot images (keep latest)
-    wsl -d $WSL_DISTRO -e bash -c "docker images ${IMAGE_NAME} --format '{{.Tag}}' | grep -v 'latest' | xargs -r -I {} docker rmi ${IMAGE_NAME}:{}"
+    Invoke-WSLCommand -Command "docker images ${IMAGE_NAME} --format '{{.Tag}}' | grep -v 'latest' | xargs -r -I {} docker rmi ${IMAGE_NAME}:{}"
     
     Write-Success "Cleanup completed"
 }
@@ -547,6 +579,7 @@ function Show-ProductionLogs {
 # Restart production
 function Restart-Production {
     Write-Info "Restarting production..."
+    if (-not (Remove-ConflictingProductionContainer)) { return $false }
     ssh $SERVER_HOST "cd $PRODUCTION_PATH && docker compose -f docker-compose.production.yml restart"
     
     Start-Sleep -Seconds 10

--- a/scripts/wsl2-deploy.ps1
+++ b/scripts/wsl2-deploy.ps1
@@ -216,10 +216,8 @@ function Build-Image {
     
     Write-Info "Executing: $buildCmd"
     
-    Invoke-WSLCommand -Command $buildCmd
-    if ($LASTEXITCODE -ne 0) { return $false }
-    
-    if ($LASTEXITCODE -eq 0) {
+    $ok = Invoke-ExternalWithProgress -FilePath "wsl" -Arguments @("-d", $WSL_DISTRO, "--cd", "/", "/bin/sh", "-lc", $buildCmd) -Activity "Building Docker image in WSL2" -TimeoutSec $TIMEOUT_BUILD_SEC
+    if ($ok) {
         Write-Success "Image built successfully: ${IMAGE_NAME}:${Tag}"
         return $true
     } else {

--- a/scripts/wsl2-deploy.ps1
+++ b/scripts/wsl2-deploy.ps1
@@ -426,6 +426,13 @@ function Remove-ConflictingProductionContainer {
         return $true
     }
 
+    # If the container is managed by docker compose, it is not a conflict.
+    ssh $SERVER_HOST "docker inspect $containerId --format '{{.Config.Labels}}' 2>/dev/null | grep -q 'com.docker.compose.project'"
+    if ($LASTEXITCODE -eq 0) {
+        Write-Info "Container is managed by docker compose; skipping removal"
+        return $true
+    }
+
     Write-Info "Removing existing container ID: $containerId"
     ssh $SERVER_HOST "docker rm -f $containerId"
 

--- a/scripts/wsl2-deploy.ps1
+++ b/scripts/wsl2-deploy.ps1
@@ -349,10 +349,9 @@ function Save-Image {
     $outputPathWSL = $OutputPath -replace '\\', '/' -replace 'C:', '/mnt/c' -replace 'c:', '/mnt/c'
     
     Write-Info "Saving ${IMAGE_NAME}:${Tag} to $OutputPath..."
-    Invoke-WSLCommand -Command "docker save ${IMAGE_NAME}:${Tag} -o '$outputPathWSL'"
-    if ($LASTEXITCODE -ne 0) { return $false }
-    
-    if ($LASTEXITCODE -eq 0) {
+    $saveCmd = "docker save ${IMAGE_NAME}:${Tag} -o '$outputPathWSL'"
+    $ok = Invoke-ExternalWithProgress -FilePath "wsl" -Arguments @("-d", $WSL_DISTRO, "--cd", "/", "/bin/sh", "-lc", $saveCmd) -Activity "Saving Docker image to tar" -TimeoutSec $TIMEOUT_SAVE_SEC
+    if ($ok) {
         $fileSize = (Get-Item $OutputPath).Length / 1MB
         Write-Success "Image saved: $OutputPath ($([math]::Round($fileSize, 2)) MB)"
         return $true

--- a/scripts/wsl2-deploy.ps1
+++ b/scripts/wsl2-deploy.ps1
@@ -508,7 +508,7 @@ function Set-ProductionImageTag {
 
     Write-Info "Setting production image tag to $ImageTag..."
     ssh $SERVER_HOST "mkdir -p $PRODUCTION_PATH"
-    ssh $SERVER_HOST "cd $PRODUCTION_PATH && if [ -f .env ]; then sed -i '/CAREBOT_IMAGE_TAG=/d' .env; fi; printf '\n%s\n' 'CAREBOT_IMAGE_TAG=$ImageTag' >> .env"
+    ssh $SERVER_HOST "cd $PRODUCTION_PATH && if [ -f .env ]; then sed -i '/^CAREBOT_IMAGE_TAG=/d' .env; fi; printf '\n%s\n' 'CAREBOT_IMAGE_TAG=$ImageTag' >> .env"
     Write-Success "Production image tag set"
 }
 


### PR DESCRIPTION
Adds targeted unit tests for the static Armageddon WH40K mission selection logic introduced in `mission_helper.py`, addressing the review feedback requesting test coverage for this area.

## Changes Made

- **New test file**: `CareBot/tests/test_static_wh40k_mission.py` with 13 unit tests covering:
  - **Static dataset path used when available**: verifies `_try_create_static_wh40k_mission` saves a static mission and returns `True` when the dataset is non-empty and the 50% random check favours it; returns `False` when random ≥ 0.5.
  - **Fallback to generator when unavailable/empty**: covers table exception (graceful `False`), count == 0, and `get_random_static_armageddon_mission` returning `None`.
  - **Winner bonus / deploy asset path handling**: verifies `_build_static_wh40k_mission_tuple` always populates `winner_bonus`, prefers `deploy_asset_path` over `map_asset_path`, falls back to `total_domination.jpg` when both are absent, and sets `rules='wh40k'` and `cell=None`.
  - **Integration tests** for `get_mission` verifying static path vs generator branching end-to-end.

Tests use `monkeypatch` to patch `sqllite_helper` and `random.random`, consistent with existing test patterns in `CareBot/tests/`.

## Testing

- ✅ All 13 new tests pass
- ✅ All 22 tests in `CareBot/tests/` pass (existing tests unaffected)